### PR TITLE
Update clients

### DIFF
--- a/config/geth-config.go
+++ b/config/geth-config.go
@@ -10,8 +10,8 @@ import (
 // Constants
 const (
 	// Tags
-	gethProdTag string = "ethereum/client-go:v1.15.10"
-	gethTestTag string = "ethereum/client-go:v1.15.10"
+	gethProdTag string = "ethereum/client-go:v1.15.11"
+	gethTestTag string = "ethereum/client-go:v1.15.11"
 )
 
 // Configuration for Geth

--- a/config/lodestar-bn-config.go
+++ b/config/lodestar-bn-config.go
@@ -5,7 +5,7 @@ import (
 )
 
 const (
-	lodestarBnTag string = "chainsafe/lodestar:v1.29.0"
+	lodestarBnTag string = "chainsafe/lodestar:v1.30.0"
 )
 
 // Configuration for the Lodestar BN

--- a/config/nethermind-config.go
+++ b/config/nethermind-config.go
@@ -11,7 +11,7 @@ import (
 // Constants
 const (
 	// Tags
-	nethermindTag string = "nethermind/nethermind:1.31.9"
+	nethermindTag string = "nethermind/nethermind:1.31.10"
 )
 
 // Configuration for Nethermind

--- a/config/nimbus-bn-config.go
+++ b/config/nimbus-bn-config.go
@@ -9,7 +9,7 @@ import (
 
 const (
 	// Tags
-	nimbusBnTag string = "statusim/nimbus-eth2:multiarch-v25.4.1"
+	nimbusBnTag string = "statusim/nimbus-eth2:multiarch-v25.5.0"
 )
 
 // Nimbus's pruning mode

--- a/config/nimbus-vc-config.go
+++ b/config/nimbus-vc-config.go
@@ -6,7 +6,7 @@ import (
 
 const (
 	// Tags
-	nimbusVcTag string = "statusim/nimbus-validator-client:multiarch-v25.4.1"
+	nimbusVcTag string = "statusim/nimbus-validator-client:multiarch-v25.5.0"
 )
 
 // Configuration for Nimbus

--- a/config/prysm-bn-config.go
+++ b/config/prysm-bn-config.go
@@ -6,8 +6,8 @@ import (
 
 const (
 	// Tags
-	prysmBnProdTag string = "nodeset/prysm:v6.0.0"
-	prysmBnTestTag string = "nodeset/prysm:v6.0.0"
+	prysmBnProdTag string = "nodeset/prysm:v6.0.2"
+	prysmBnTestTag string = "nodeset/prysm:v6.0.2"
 )
 
 // Configuration for the Prysm BN

--- a/config/reth-config.go
+++ b/config/reth-config.go
@@ -9,7 +9,7 @@ import (
 
 // Constants
 const (
-	rethTag string = "ghcr.io/paradigmxyz/reth:v1.3.12"
+	rethTag string = "ghcr.io/paradigmxyz/reth:v1.4.1"
 )
 
 // Configuration for Reth


### PR DESCRIPTION
- Updated Geth to [v1.15.11](https://github.com/ethereum/go-ethereum/releases/tag/v1.15.11)
- Updated Nethermind to [v1.31.10](https://github.com/NethermindEth/nethermind/releases/tag/1.31.10)
- Updated Reth to [v1.4.1](https://github.com/paradigmxyz/reth/releases/tag/v1.4.1)

- Updated Lodestar to [v1.30.0](https://github.com/ChainSafe/lodestar/releases/tag/v1.30.0)
- Updated Nimbus to [v25.5.0](https://github.com/status-im/nimbus-eth2/releases/tag/v25.5.0)
- Updated Prysm to [v6.0.2](https://github.com/OffchainLabs/prysm/releases/tag/v6.0.2)